### PR TITLE
Fix RWS+Mercs and LC

### DIFF
--- a/arch/index.js
+++ b/arch/index.js
@@ -247,8 +247,8 @@
 	this.viewArtifacts = function() {
 		if (View.raw.sv) {
 			var svs,i,reinc;
-			$(".viewer-results").empty().html("<b>Excavation:</b> " + View.raw.sv.x + " values ahead (" + 
-			(View.raw.eligible.length > 0 ? View.raw.sv.x / View.raw.eligible.length + " Excavations)":"Unable to move small values due to 0 eligible artifacts)") + " with <b>Small Value:</b> " + View.raw.sv.y);
+			$(".viewer-results").empty().html("<b>Excavation:</b> " + View.raw.sv.x + " values ahead (" +
+			(View.raw.eligible.length > 0 ? Math.ceil(View.raw.sv.x / View.raw.eligible.length) + " Excavations)":"Unable to move small values due to 0 eligible artifacts)") + " with <b>Small Value:</b> " + View.raw.sv.y);
 			if (View.raw.unowned.length) {
 				$(".viewer-results").append("<br><br><table><tbody>");
 				svs = View.raw.eligible.length > 1 ? "<th> Small Value Shifts Required <a>(?)</a></th>" : "";
@@ -382,8 +382,13 @@
 	$('#chartcontainer').on('click', function(e) {
 		var activeElement = Controller.chart.getElementAtEvent(e);
 		if(activeElement.length) {
-			View.raw.sv = activeElement[0]._chart.config.data.datasets[0].data[activeElement[0]._index];
+			//clicked dot turns red, all other dots revert to default (blue)
+			Controller.chart.data.datasets[0]._meta[Controller.chart.id].data.forEach(function(e){delete e.custom;});
+			activeElement[0].custom = {backgroundColor : 'rgba(255, 0, 0, 0.7)'};
+			View.raw.sv = Controller.chart.data.datasets[0].data[activeElement[0]._index];
 			Controller.viewArtifacts();
+			Controller.chart.update();
+
 		}
 	});
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -532,6 +532,19 @@ function olJoin(a) {
       return n;
     };
 
+    this.hasSpell = function(save, spell) {
+            var _spell = util.assoc.spells.find(function(element) {
+                    return element.name == spell || element.id == spell;
+            });
+            if(! _spell) return false;
+            if(_spell.name == "Catalyst") {
+                    return this.challenge_active(save,991) || this.upgrade_owned(save,940) || (save.reincarnation >= 130 && this.upgrade_owned(save,142019) && save.elitePrestigeFaction == 14)
+            }
+            return _spell.faction != null ? (save.faction == _spell.faction || save.prestigeFaction == _spell.faction || save.elitePrestigeFaction == _spell.faction)
+            || save.mercSpell1 == _spell.id || save.mercSpell2 == _spell.id || this.upgrade_owned(save,_spell.perk2)
+            : (save.alignment == _spell.alignment || save.secondaryAlignment == _spell.alignment) || (_spell.perk2 && this.upgrade_owned(save,_spell.perk2)) ;
+    };
+
     this.blankSave = function() {
       var save = {
         upgrades: {},
@@ -590,33 +603,33 @@ function olJoin(a) {
     this.spells = [
       {id: 18, name: 'Tax Collection'},
       {id: 3, name: 'Call to Arms'},
-      {id: 12, name: 'Holy Light'},
-      {id: 6, name: 'Fairy Chanting'},
-      {id: 14, name: 'Moon Blessing'},
-      {id: 9, name: 'God\'s Hand'},
-      {id: 1, name: 'Blood Frenzy'},
-      {id: 8, name: 'Goblin\'s Greed'},
-      {id: 15, name: 'Night Time'},
-      {id: 11, name: 'Hellfire Blast'},
-      {id: 7, name: 'Gem Grinder'},
-      {id: 13, name: 'Lightning Strike'},
-      {id: 10, name: 'Grand Balance'},
-      {id: 2, name: 'Brainwave'},
-      {id: 5, name: 'Diamond Pickaxe'},
-      {id: 4, name: 'Combo Strike'},
+      {id: 12, name: 'Holy Light', alignment: 1},
+      {id: 6, name: 'Fairy Chanting', faction: 0, perk2: 680},
+      {id: 14, name: 'Moon Blessing', faction: 1, perk2: 672},
+      {id: 9, name: 'God\'s Hand', faction: 2, perk2: 651},
+      {id: 1, name: 'Blood Frenzy', alignment: 2},
+      {id: 8, name: 'Goblin\'s Greed', faction: 3, perk2: 684},
+      {id: 15, name: 'Night Time', faction: 4, perk2: 692},
+      {id: 11, name: 'Hellfire Blast', faction: 5, perk2: 656},
+      {id: 7, name: 'Gem Grinder', alignment: 3},
+      {id: 13, name: 'Lightning Strike', faction: 6, perk2: 688},
+      {id: 10, name: 'Grand Balance', faction: 7, perk2: 664},
+      {id: 2, name: 'Brainwave', faction: 8, perk2: 676},
+      {id: 5, name: 'Diamond Pickaxe', faction: 9, perk2: 668},
+      {id: 4, name: 'Combo Strike', faction: 10, perk2: 660},
       {id: 17, name: 'Spiritual Surge'},
-      {id: 21, name: 'Dragon\'s Breath'},
+      {id: 21, name: 'Dragon\'s Breath', faction: 12, perk2: 696},
       {id: 19, name: 'Hailstorm'},
       {id: 20, name: 'Heatwave'},
       {id: 23, name: 'Shadow Embrace'},
       {id: 24, name: 'Wail of the Banshee'},
       {id: 22, name: 'Cannibalize'},
-      {id: 25, name: 'Temporal Flux'},
-      {id: 26, name: 'All Creation'},
-      {id: 27, name: 'Maelstrom'},
-      {id: 28, name: 'Infinite Spiral'},
-      {id: 29, name: 'Limited Wish'},
-      {id: 30, name: 'Precognition'},
+      {id: 25, name: 'Temporal Flux', alignment: 4, perk2: 1019},
+      {id: 26, name: 'All Creation', alignment: 6, perk2: 1009},
+      {id: 27, name: 'Maelstrom', alignment: 5, perk2: 1014},
+      {id: 28, name: 'Infinite Spiral', faction: 15, perk2: 969},
+      {id: 29, name: 'Limited Wish', faction: 14, perk2: 963},
+      {id: 30, name: 'Precognition', faction: 13, perk2: 957},
       {id: 31, name: 'Catalyst'},
     ];
     this.spellsRNG = [

--- a/rws/index.js
+++ b/rws/index.js
@@ -87,7 +87,7 @@
 		var lightningForecast = '';
 
 		// Check if the save actually has Lightning Strikes to forecast
-			if (!(save.faction == 6 || save.mercSpell1 == 13 || save.mercSpell2 == 13 || util.save.upgrade_owned(save, 688))) {
+			if (!util.save.hasSpell(save,"Lightning Strike")) {
 			 	lightningMessage = 'You don\'t have Lightning Strike.';
 			 	lightningForecast = 'No Lightning.';
 			} else if (save.alignment != 3 && !util.save.upgrade_owned(save, 688)) {
@@ -160,7 +160,7 @@
 			var breathForecast = '';
 
 			// Check if the save actually has Dragons Breath to forecast
-			if (!(save.prestigeFaction == 12 || save.mercSpell1 == 21 || save.mercSpell2 == 21 || util.save.upgrade_owned(save, 696))) {
+			if (!util.save.hasSpell(save,"Dragon's Breath")) {
 				breathMessage = 'You don\'t have Dragon\'s Breath.';
 				breathForecast = 'No Dragon\'s Breath.';
 			}
@@ -275,7 +275,7 @@
             var maelstromForecast = '';
 
             // Check if the save actually has Maelstrom to forecast
-            if (!(util.save.upgrade_owned(save,748))) {
+            if (!util.save.hasSpell(save,"Maelstrom")) {
                 maelstromMessage = 'You don\'t have Maelstrom.';
                 maelstromForecast = 'No Chaos that is trying to pull you in.';
             }
@@ -360,7 +360,7 @@
             var limitedWishForecast = '';
 
             // Check if the save actually has Limited Wish to forecast
-            if (save.elitePrestigeFaction != 14 && !util.save.upgrade_owned(save,963)) {
+            if (!util.save.hasSpell(save,"Limited Wish")) {
                 limitedWishMessage = 'You don\'t have Limited Wish.';
                 limitedWishForecast = 'The Genie is in an another lamp.';
             }
@@ -481,7 +481,7 @@
             var catalystForecast = '';
 
             // Check if the save actually has Catalyst to forecast
-	    if (!util.save.challenge_active(save,991) && !util.save.upgrade_owned(save,940) && !(save.reincarnation >= 130 && util.save.upgrade_owned(save,142019) && save.elitePrestigeFaction == 14)) {
+	    if (!util.save.hasSpell(save,"Catalyst")) {
                 catalystMessage = 'You don\'t have Catalyst.';
                 catalystForecast = 'Who knew chaotic blood was so magical?';
             }
@@ -498,46 +498,8 @@
 
 			//check if djinn challenge 3 is active
             catalystTargets = util.save.challenge_active(save,991)?2:1;
-
-            catalystEligibleEffects = catalystEffects.slice();
-
-            // ugh
-            if (save.faction == 0 || util.save.upgrade_owned(save,680))
-            {
-                catalystEligibleEffects.splice(catalystEligibleEffects.indexOf("Fairy Chanting"), 1);
-            }
-            if (save.faction == 1 || util.save.upgrade_owned(save,672))
-            {
-                catalystEligibleEffects.splice(catalystEligibleEffects.indexOf("Moon Blessing"), 1);
-            }
-            if (save.faction == 2 || util.save.upgrade_owned(save,651))
-            {
-                catalystEligibleEffects.splice(catalystEligibleEffects.indexOf("God's Hand"), 1);
-            }
-            if (save.faction == 3 || util.save.upgrade_owned(save,684))
-            {
-                catalystEligibleEffects.splice(catalystEligibleEffects.indexOf("Goblin's Greed"), 1);
-            }
-            if (save.faction == 4 || util.save.upgrade_owned(save,692))
-            {
-                catalystEligibleEffects.splice(catalystEligibleEffects.indexOf("Night Time"), 1);
-            }
-            if (save.faction == 5 || util.save.upgrade_owned(save,656))
-            {
-                catalystEligibleEffects.splice(catalystEligibleEffects.indexOf("Hellfire Blast"), 1);
-            }
-            if (save.alignment == 3)
-            {
-                catalystEligibleEffects.splice(catalystEligibleEffects.indexOf("Gem Grinder"), 1);
-            }
-            if (save.alignment == 1)
-            {
-                catalystEligibleEffects.splice(catalystEligibleEffects.indexOf("Holy Light"), 1);
-            }
-            if (save.alignment == 2)
-            {
-                catalystEligibleEffects.splice(catalystEligibleEffects.indexOf("Blood Frenzy"), 1);
-            }
+	    //filter out already owned spells
+            catalystEligibleEffects = catalystEffects.filter(spell => !util.save.hasSpell(save,spell));
 			//ugh2
 	    var spellIDs = [null,null,'Holy Light','Blood Frenzy','Gem Grinder',null,null,null,'Fairy Chanting','Moon Blessing', 'God\'s Hand', 'Goblin\'s Greed', 'Night Time', 'Hellfire Blast'];
             $('#catalystMessage').html('<b>Catalyst</b><br>Your RNG state is: ' + catalystRNG.state + '.');


### PR DESCRIPTION
Lara: Dots turn red when you click them, small fix on excavations ahead (ceiling was forgotten)

Util: Added a hasSpell function to reduce repetitive code, currently works for just faction and alignment spells. Added faction/alignment and perk2 information to util.save.spells (If too messy can move to a different variable)

RWS: Adapted all current spell owned checks to hasSpell, so A3 mercs works correctly with all spells. Also cleaned up Catalyst code slightly.