### PR TITLE
Fix Unlocked/Owned, Save Codec fixes

### DIFF
--- a/edit/edit.js
+++ b/edit/edit.js
@@ -86,7 +86,7 @@
     ssTiers: [401701, 401702, 401703, 401704, 401705, 401706],
   };
 
-  var allResearches = upgradeIDs.spellcraft.concat(upgradeIDs.craftsmanship, upgradeIDs.divine, upgradeIDs.economics, upgradeIDs.alchemy, upgradeIDs.warfare, upgradeIDs.forbidden)
+  var allResearches = upgradeIDs.spellcraft.concat(upgradeIDs.craftsmanship, upgradeIDs.divine, upgradeIDs.economics, upgradeIDs.alchemy, upgradeIDs.warfare, upgradeIDs.forbidden);
 
 
   for (var x in trophyIDs) {
@@ -838,15 +838,15 @@
         all_unlocked: {
           set: function(x) {
             for (var i of allResearches) {
-              if (x && !this.upgrades[i]) { this.upgrades[i] = {_id: this.i, u1: false, u2: false, u3: false, s: 0}; }
-              else if (this.upgrades[i]) { delete this.upgrades[i]; }
+              if (x && !this.upgrades[i]) { Vue.set(this.upgrades,i,{_id: i, u1: false, u2: false, u3: false, s: 0}); }
+              else if (this.upgrades[i] && !x) { Vue.delete(this.upgrades,i); }
             }
           }
         },
         all_owned: {
           set: function(x) {
             for (var i of allResearches) {
-              if (!this.upgrades[i] && x) { this.upgrades[i] = {_id: i, u1: true, u2: false, u3: false, s: 0}; }
+              if (!this.upgrades[i] && x) { Vue.set(this.upgrades,i,{_id: i, u1: true, u2: false, u3: false, s: 0}); }
               else { this.upgrades[i].u1 = x; }
             }
           }

--- a/lib/savecodec2.js
+++ b/lib/savecodec2.js
@@ -363,9 +363,9 @@
 				// Object case, read the object members and group the results in an object
 				else if (item.format === 'Object') {
 					var key = this.parseKey(parent, item.key);
+					var length = item.length ? this.parseValue(item.length.format) : item.members.length ;	
 					key[0][key[1]] = {};
-
-					for (var i in item.members)
+					for (var i = 0; i < length; ++i)
 						this.parseItem(key[0][key[1]], item.members[i]);
 				}
 
@@ -472,7 +472,9 @@
 				// Object case, read the object members and group the results in an object
 				else if (item.format === 'Object') {
 					var key = item.key ? this.parseKeyValue(parent, item.key) : parent;
-					for (var i in item.members)
+					var length = item.length ? Object.keys(key).length : item.members.length;
+					if (item.length) this.compileValue(item.length.format, length);
+					for (var i = 0; i < length; ++i)
 						this.compileItem(key, item.members[i]);
 				}
 
@@ -604,8 +606,8 @@
 						{ 'format': 'Int8', 'key': 'targeteffect' },
 					] },
 				},
-                { 'format': 'Uint32', 'key': 'LimitedWishTarget', 'cond': '_base/saveVersion >= 48' },			// 
-				{ 'format': 'Float64', 'key': 'LimitedWishStrength', 'cond': '_base/saveVersion >= 48' },            //
+                { 'format': 'Uint32', 'key': 'limitedWishTarget', 'cond': '_base/saveVersion >= 48' },			// 
+				{ 'format': 'Float64', 'key': 'limitedWishStrength', 'cond': '_base/saveVersion >= 48' },            //
 				{ 'format': 'Int8', 'key': 'snowballScryUses', 'cond': '_base/saveVersion >= 9' },			// The number of times Scried for snowballs
 				{ 'format': 'Uint16', 'key': 'snowballSize', 'cond': '_base/saveVersion >= 9' },			// The number of uncollected snowballs
 				{ 'format': 'Uint32', 'key': 'lastGiftDate', 'cond': '_base/saveVersion >= 9' },			// Date of most recently earned Gift
@@ -646,8 +648,9 @@
 				{ 'format': 'Uint32', 'key': 'currentDay', 'cond': '_base/saveVersion >= 41' },             // For Planetary force time calculation
 				{ 'format': 'Uint32', 'key': 'other21' },													// import only works if <= some hardcoded value (save length upper limit check)
 				{ 'format': 'Int8', 'key': 'saveRevision' },												//
-				{ 'format': 'Object', 'key': 'options', 'members': [										// The list of options
-					{ 'format': 'Int8', 'key': 'len' },
+				{ 'format': 'Object', 'key': 'options', 		// The list of options
+					'length': { 'format': 'Int8', 'key': '_len/optionslength' },
+					'members': [										
 					{ 'format': 'Int8', 'key': 'notation' },
 					{ 'format': 'Int8', 'key': 'thousands_sep' },
 					{ 'format': 'Int8', 'key': 'block_bg_clicks' },
@@ -676,9 +679,12 @@
 					{ 'format': 'Int8', 'key': 'disable_autoclicks' },
 					{ 'format': 'Int8', 'key': 'spell_tooltips_persist' },
 					{ 'format': 'Int8', 'key': 'buy_all_upgrades' },
+					{ 'format': 'Int8', 'key': 'new0' },
+					{ 'format': 'Int8', 'key': 'new1' }
 				] },
-				{ 'format': 'Object', 'key': 'tutorials', 'members': [
-					{ 'format': 'Int8', 'key': 'len' },
+				{ 'format': 'Object', 'key': 'tutorials',
+					'length': { 'format': 'Int8', 'key': '_len/optionslength' },
+					'members': [
 					{ 'format': 'Int8', 'key': 'click_on_bg' },         // 0
 					{ 'format': 'Int8', 'key': 'buy_a_farm' },          // 1
 					{ 'format': 'Int8', 'key': 'find_FCs' },            // 2
@@ -712,6 +718,8 @@
 					{ 'format': 'Int8', 'key': 'new4' },
 					{ 'format': 'Int8', 'key': 'new5' },
 					{ 'format': 'Int8', 'key': 'new6' },
+					{ 'format': 'Int8', 'key': 'new7' },
+					{ 'format': 'Int8', 'key': 'new8' },
 				] },
 			] };
 


### PR DESCRIPTION
edit.js: Vue can't keep track of some array modifying properties: The two involved were arr[foo] = bar, and delete foo. Both of these cases break Vue's tracking. Fortunately, Vue has Vue.set and Vue.delete to properly do both. Does make it slightly laggy to go from no owned to all owned, but it works properly now.

savecodec2.js: Fixed an upper case in save property for limited wish, also fixed options and tutorials.